### PR TITLE
Modify javadoc for TaskList::findTasks method

### DIFF
--- a/src/main/java/lawrence/task/TaskList.java
+++ b/src/main/java/lawrence/task/TaskList.java
@@ -114,7 +114,7 @@ public class TaskList {
     }
 
     /**
-     * Returns a {@link TaskList} containing tasks that match the given query.
+     * Returns a {@link TaskList} containing tasks with descriptions that match the given query.
      *
      * @param query the string to match task descriptions
      * @return a {@link TaskList} containing hits


### PR DESCRIPTION
The current javadoc description for the
method does not fully explain what instance
fields the query matches when the method
checks for a match.

Changing the javadoc to specify that the
description of the task is used for matching
better explains the purpose of the method.

Let's modify the javadoc to specify that
string matching is done with the task
description to improve the documentation
for the function.